### PR TITLE
S3 capabilities of Metaflow

### DIFF
--- a/s3_experiments/README.md
+++ b/s3_experiments/README.md
@@ -1,0 +1,32 @@
+## Setting up S3 access
+
+The main goal of these experiments were to tinker with all aspects of S3 manipulation and listing them below.
+
+### Use Case 1:
+
+Propagating data between steps and quickly switching between local and remote access for debugging. This is supposedly more space optimal.
+
+In `s3_artifact_propagate.py`, we can switch between a local folder and S3 by doing the following for a remote run
+
+`python s3_read_write.py  --datastore s3 --datastore-root s3://ish-metaflow-hackday run`
+
+Or, the following for a local run
+
+`python s3_read_write.py  --datastore local --datastore-root s3://ish-metaflow-hackday run`
+
+This will create a S3 directory locally to run your artifacts again
+
+To not specify the S3 directory each time, run `metaflow configure aws` where you can set defaults for tasks like S3, Batch and Step Functions
+
+Now, you may simply run it as
+
+`python s3_read_write.py  --datastore <your-mode> run`
+
+### Use Case 2:
+
+Workflows become more optimal with S3 involved when we exploit parallelism and other operations. Another advantage of this flow is that we can control the exact locations of stores and writes whereas
+in the previous flow, it would be forcefully written to a path `s3://ish-metaflow-hackday/LinearFlow` with metadata and data subdirectories. The throughput and operations supported is also much higher in the current case.
+
+In `s3_robust_operations.py`, we document single, multiple and parallel reads and writes. This runs entirely on AWS.
+
+Run the script as`python s3_robust_operations.py run`

--- a/s3_experiments/s3_artifact_propagate.py
+++ b/s3_experiments/s3_artifact_propagate.py
@@ -1,0 +1,21 @@
+from metaflow import FlowSpec, step
+
+
+class LinearFlow(FlowSpec):
+    @step
+    def start(self):
+        self.my_var = "hello world"
+        self.next(self.a)
+
+    @step
+    def a(self):
+        print("the data artifact is: %s" % self.my_var)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("the data artifact is still: %s" % self.my_var)
+
+
+if __name__ == "__main__":
+    LinearFlow()

--- a/s3_experiments/s3_robust_operations.py
+++ b/s3_experiments/s3_robust_operations.py
@@ -1,0 +1,50 @@
+from metaflow import FlowSpec, step, S3
+import json
+
+
+class S3DemoFlow(FlowSpec):
+    @step
+    def start(self):
+        with S3(run=self, s3root="s3://ish-metaflow-hackday") as s3:
+            print("Singular scoped puts")
+            message = json.dumps({"message": "hello world!"})
+            s3.put("sample_obj_1", message)
+            s3.put("sample_obj_2", message)
+        self.next(self.singular_access)
+
+    @step
+    def singular_access(self):
+        with S3(run=self, s3root="s3://ish-metaflow-hackday") as s3:
+            print("Singular scoped gets")
+            s3obj_1 = s3.get("sample_obj_1")
+            print("Object found at", s3obj_1.url)
+            print("Message:", json.loads(s3obj_1.text))
+            s3obj_2 = s3.get("sample_obj_2")
+            print("Object found at", s3obj_2.url)
+            print("Message:", json.loads(s3obj_2.text))
+        self.next(self.multiple_access)
+
+    @step
+    def multiple_access(self):
+        print("Multiple object access")
+        many = {"first_key": "foo", "second_key": "bar"}
+        with S3(s3root="s3://ish-metaflow-hackday") as s3:
+            s3.put_many(many.items())
+            objs = s3.get_many(["first_key", "second_key"])
+            print(objs)
+        self.next(self.recursive_listing)
+
+    @step
+    def recursive_listing(self):
+        with S3(run=self, s3root="s3://ish-metaflow-hackday") as s3:
+            objs = s3.get_all()
+            print(objs)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    S3DemoFlow()


### PR DESCRIPTION
Clubhouse: [ch124496](https://app.clubhouse.io/joinroot/story/124496/ensure-metaflow-can-upload-to-s3-by-using-various-s3-interaction-use-cases)

**What?**

Demonstrates single, multiple and parallel reads and writes and recursive S3 access in the data-science-admin account

**Why?**

Our use cases for S3 usually involve some specialized operations over the low level API and we usually have to write extra code. If it comes straight out of the box well tested, we might as well use it.